### PR TITLE
Use `AsSpan()` for parsing to `double`

### DIFF
--- a/src/Converter.Temperature/Extensions/To/ToStringExtensions.cs
+++ b/src/Converter.Temperature/Extensions/To/ToStringExtensions.cs
@@ -564,7 +564,7 @@ public static class ToStringExtensions
         int fractionalCount)
     {
         string convertedTemp = string.Empty;
-        if (double.TryParse(temp, out double inputAsDouble))
+        if (double.TryParse(temp.AsSpan(), out double inputAsDouble))
             convertedTemp = Rounder(methodToParse(inputAsDouble), fractionalCount)
                 .ToString(CultureInfo.InvariantCulture);
 


### PR DESCRIPTION
No improvement in the benchmarks.